### PR TITLE
Improve Release Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ jobs:
     name: create release draft
     steps:
       - uses: actions/checkout@v1
+        with:
+          fetch-depth: 0
 
       - name: 'Get Previous tag'
         id: previoustag
@@ -42,13 +44,15 @@ jobs:
           name: T-Systems MMS
           email: frage@t-systems-mms.com
 
-      - name: Generate changelog for the release
-        uses: charmixer/auto-changelog-action@v1.1
+      # do a second checkout to prevent race situation
+      # changelog gets updated but action works on old commit id
+      - uses: actions/checkout@v2.3.4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          since_tag: ${{ steps.previoustag.outputs.tag }}
-          future_release: ${{ steps.version.outputs.next-version }}
-          output: CHANGELOGRELEASE.md
+          ref: master
+
+      - name: Generate changelog for the release
+        run: |
+          sed '/## \[${{ steps.previoustag.outputs.tag }}\]/Q' CHANGELOG.md > CHANGELOGRELEASE.md
 
       - name: Read CHANGELOG.md
         id: package


### PR DESCRIPTION
in the past we used to call github-changelog-generator twice. This hav many Problems (API Limit, breaking Workflows)

This change only calls github-changelog-generator once and the workflow should never fail when creating the Release in Github