### PR TITLE
API: handle 404 error

### DIFF
--- a/plugins/module_utils/atlas.py
+++ b/plugins/module_utils/atlas.py
@@ -58,7 +58,7 @@ class AtlasAPIObject:
 
         content = ""
         error = ""
-        if rsp and info["status"] != 204:
+        if rsp and info["status"] not in (204, 404):
             content = json.loads(rsp.read())
         if info["status"] >= 400:
             try:


### PR DESCRIPTION
MongoDB Atlas API does not return a json when a 404 occurred